### PR TITLE
Accept unsigned immediate operand on x86

### DIFF
--- a/x86data.js
+++ b/x86data.js
@@ -862,7 +862,8 @@ $export[$as] =
 
     ["push"             , "ib"                                             , "I"       , "6A ib"                            , "ANY"],
     ["push"             , "iw"                                             , "I"       , "66 68 iw"                         , "ANY"],
-    ["push"             , "id"                                             , "I"       , "68 id"                            , "ANY"],
+    ["push"             , "id/ud"                                          , "I"       , "68 id"                            , "X86"],
+    ["push"             , "id"                                             , "I"       , "68 id"                            , "X64"],
 
     ["push"             , "R:cs"                                           , "NONE"    , "0E"                               , "X86"],
     ["push"             , "R:ss"                                           , "NONE"    , "16"                               , "X86"],


### PR DESCRIPTION
Negative, 32-bit immediates should be allowed in x86 mode.